### PR TITLE
Default values.yaml for ArgoCD helm on spoke

### DIFF
--- a/gitops/fleet/charts/argo-cd/values.yaml
+++ b/gitops/fleet/charts/argo-cd/values.yaml
@@ -1,0 +1,3 @@
+server:
+  service:
+    type: LoadBalancer


### PR DESCRIPTION
Adding default values.yaml for ArgoCD helm release run on spoke clusters. For now, it only changes the type of the service to LoadBalancer to expose the UI so attendees can easily explore it during the workshop.